### PR TITLE
Prevent NPE

### DIFF
--- a/app/src/main/java/org/example/jt/pizzamaker/Pizza.java
+++ b/app/src/main/java/org/example/jt/pizzamaker/Pizza.java
@@ -77,7 +77,7 @@ public class Pizza {
 
         private String setName(String name){
 
-            if(name.equals("")){
+            if(name == null || name.trim().isEmpty()){
                 return "Pizza with No Name";
             }
             else{


### PR DESCRIPTION
It is possible that `name` is `null`
thus its always a better way to write `"".equals(str)` than the other way around as `""` is guaranteed not `null`.
A better check would be `name == null || name.trim().isEmpty()` which would cover more cases: null, empty string, only spaces string.
It is also possible to use Android's `android.text.TextUtils` class but introduces Android platform dependencies
`TextUtils.isEmpty(name) || TextUtils.isEmpty(name.trim())`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pandawarrior91/pizza-maker/1)

<!-- Reviewable:end -->
